### PR TITLE
Uses CACHE_TAG constants instead of hardcoded cache tag values

### DIFF
--- a/Observer/CatalogCategoryCollectionLoadAfter.php
+++ b/Observer/CatalogCategoryCollectionLoadAfter.php
@@ -23,6 +23,7 @@ namespace MSP\APIEnhancer\Observer;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use MSP\APIEnhancer\Api\TagInterface;
+use Magento\Catalog\Model\Category;
 
 class CatalogCategoryCollectionLoadAfter implements ObserverInterface
 {
@@ -44,11 +45,11 @@ class CatalogCategoryCollectionLoadAfter implements ObserverInterface
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         $collection = $observer->getCategoryCollection();
-        $tags = ['catalog_category'];
-        $ids = array_keys($collection->getItems());
+        $tags       = [Category::CACHE_TAG];
+        $ids        = array_keys($collection->getItems());
 
         foreach ($ids as $id) {
-            $tags[] = 'catalog_category_' . $id;
+            $tags[] = Category::CACHE_TAG . '_' . $id;
         }
 
         $this->tag->addTags($tags);

--- a/Observer/CatalogCategoryLoadAfter.php
+++ b/Observer/CatalogCategoryLoadAfter.php
@@ -23,6 +23,7 @@ namespace MSP\APIEnhancer\Observer;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use MSP\APIEnhancer\Api\TagInterface;
+use Magento\Catalog\Model\Category;
 
 class CatalogCategoryLoadAfter implements ObserverInterface
 {
@@ -43,7 +44,7 @@ class CatalogCategoryLoadAfter implements ObserverInterface
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
-        $productId = $observer->getCategory()->getId();
-        $this->tag->addTags(['catalog_category', 'catalog_category_' . $productId]);
+        $categoryId = $observer->getCategory()->getId();
+        $this->tag->addTags([Category::CACHE_TAG, Category::CACHE_TAG . '_' . $categoryId]);
     }
 }

--- a/Observer/CatalogProductCollectionLoadAfter.php
+++ b/Observer/CatalogProductCollectionLoadAfter.php
@@ -29,6 +29,7 @@ use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use MSP\APIEnhancer\Api\CustomerAuthInterface;
 use MSP\APIEnhancer\Api\TagInterface;
+use Magento\Catalog\Model\Product;
 
 class CatalogProductCollectionLoadAfter implements ObserverInterface
 {
@@ -90,7 +91,7 @@ class CatalogProductCollectionLoadAfter implements ObserverInterface
 
         $fixCatalogRules = !!$this->scopeConfig->getValue(static::XML_PATH_FIX_CATALOG_RULES);
 
-        $tags = ['catalog_product'];
+        $tags       = [Product::CACHE_TAG];
         $productIds = array_keys($collection->getItems());
 
         if ($fixCatalogRules) {
@@ -115,7 +116,7 @@ class CatalogProductCollectionLoadAfter implements ObserverInterface
             if ($fixCatalogRules && isset($rulePrices[$product->getId()])) {
                 $product->setCustomAttribute('special_price', $rulePrices[$product->getId()]);
             }
-            $tags[] = 'catalog_product_' . $product->getId();
+            $tags[] = Product::CACHE_TAG . '_' . $product->getId();
         }
 
         $this->tag->addTags($tags);

--- a/Observer/CatalogProductLoadAfter.php
+++ b/Observer/CatalogProductLoadAfter.php
@@ -29,6 +29,7 @@ use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use MSP\APIEnhancer\Api\CustomerAuthInterface;
 use MSP\APIEnhancer\Api\TagInterface;
+use Magento\Catalog\Model\Product;
 
 class CatalogProductLoadAfter implements ObserverInterface
 {
@@ -112,6 +113,6 @@ class CatalogProductLoadAfter implements ObserverInterface
             }
         }
 
-        $this->tag->addTags(['catalog_product', 'catalog_product_' . $productId]);
+        $this->tag->addTags([Product::CACHE_TAG, Product::CACHE_TAG .'_' . $productId]);
     }
 }


### PR DESCRIPTION
## Description
Since Magento 2.2.x the cache tags for the catalog categories and catalog products have changed due to varnish `X-Magento-Tags` header content getting huge when there are a lot of products or categories getting loaded in page

[MAGETWO-57851: X-Magento-Tags header too large](https://github.com/magento/magento2/commit/2529ec4fc035eec8c524e94c0b73efd8c3efbb28)

Catalog Product Cache Tags: 
https://github.com/magento/magento2/blob/2.1/app/code/Magento/Catalog/Model/Product.php#L60
https://github.com/magento/magento2/blob/2.2/app/code/Magento/Catalog/Model/Product.php#L61

Catalog Catagory Cache Tags: 
https://github.com/magento/magento2/blob/2.1/app/code/Magento/Catalog/Model/Category.php#L70
https://github.com/magento/magento2/blob/2.2/app/code/Magento/Catalog/Model/Category.php#L72

Hence the `Magento\CacheInvalidate\Model\PurgeCache` class is not able to purge the respective API endpoint which when product or category entites are changed.

This PR will:
- Will use the `CACHE_TAG` const from the respective model classes to generate the `X-Magento-Tags`