### PR TITLE
Update Classes to Proxy

### DIFF
--- a/Plugin/AppInterfacePlugin.php
+++ b/Plugin/AppInterfacePlugin.php
@@ -20,9 +20,9 @@
 
 namespace MSP\APIEnhancer\Plugin;
 
-use MSP\APIEnhancer\Api\CacheManagementInterface;
-use MSP\APIEnhancer\Api\EnhancerManagementInterface;
-use MSP\APIEnhancer\Api\VarnishManagementInterface;
+use MSP\APIEnhancer\Api\CacheManagementInterface\Proxy as CacheManagementInterface;
+use MSP\APIEnhancer\Api\EnhancerManagementInterface\Proxy as EnhancerManagementInterface;
+use MSP\APIEnhancer\Api\VarnishManagementInterface\Proxy as VarnishManagementInterface;
 
 class AppInterfacePlugin
 {


### PR DESCRIPTION
Lazy Loading of classes to prevent set different locale in MultiWebsite Store

When you have a MultiWebsite with different locales if you don't use proxy, the flow of loading the classes in their __construct(),  set locale random for every website.

You can have problem in:
- Mail Translation
- Admin Translations
 